### PR TITLE
Change cli option: `-url-encode-body` -> `-url-encode-body-replacement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Usage of boson:
         HTTP timeout for webhook request (default 0, i.e. no-timeout)
   -url string
         URL for webhook endpoint. It replaces "{{ line }}" token with got line string
-  -url-encode-body
-        Encode the body of webhook request with url (percent) encoding; for "application/x-www-form-urlencoded"
+  -url-encode-body-replacement
+        Encode the replacement of the body (i.e. the contents of "{{ line }}") of webhook request with url (percent) encoding; for "application/x-www-form-urlencoded"
 ```
 
 ### Example: Send every line to the webhook endpoint

--- a/cmd/boson/boson.go
+++ b/cmd/boson/boson.go
@@ -30,7 +30,7 @@ func main() {
 	var webhookHeadersOpt stringSlice
 	var webhookBody string
 	var webhookTimeoutSec int
-	var urlEncodeBody bool
+	var urlEncodeBodyReplacement bool
 
 	flag.BoolVar(&everyLine, "every-line", false, "Run with every-line mode")
 	flag.StringVar(&filterRegexp, "filter-regexp", "", "Regexp for line filtering, run with regexp-filter mode")
@@ -39,7 +39,7 @@ func main() {
 	flag.Var(&webhookHeadersOpt, "header", "HTTP header for webhook (example: `Content-Type: application/json`). It replaces \"{{ line }}\" token with got line string")
 	flag.StringVar(&webhookBody, "body", "", "HTTP body for webhook request")
 	flag.IntVar(&webhookTimeoutSec, "timeout-sec", 0, "HTTP timeout for webhook request (default 0, i.e. no-timeout)")
-	flag.BoolVar(&urlEncodeBody, "url-encode-body", false, "Encode the body of webhook request with url (percent) encoding; for \"application/x-www-form-urlencoded\"")
+	flag.BoolVar(&urlEncodeBodyReplacement, "url-encode-body-replacement", false, "Encode the replacement of the body (i.e. the contents of \"{{ line }}\") of webhook request with url (percent) encoding; for \"application/x-www-form-urlencoded\"")
 
 	flag.Parse()
 
@@ -60,7 +60,7 @@ func main() {
 		webhookHeaders,
 		webhookBody,
 		time.Duration(webhookTimeoutSec)*time.Second,
-		urlEncodeBody,
+		urlEncodeBodyReplacement,
 	)
 	if err != nil {
 		log.Fatalf("[error] %s", err)

--- a/webhook/http_sender.go
+++ b/webhook/http_sender.go
@@ -11,16 +11,16 @@ import (
 
 // HTTPSender is a webhook client based on HTTP.
 type HTTPSender struct {
-	HTTPMethod    string
-	URL           string
-	Headers       http.Header
-	Body          string
-	Client        *http.Client
-	URLEncodeBody bool
+	HTTPMethod               string
+	URL                      string
+	Headers                  http.Header
+	Body                     string
+	Client                   *http.Client
+	URLEncodeBodyReplacement bool
 }
 
 // NewHTTPSender returns a HTTPSender instance.
-func NewHTTPSender(httpMethod string, url string, headers http.Header, body string, timeout time.Duration, urlEncodeBody bool) (*HTTPSender, error) {
+func NewHTTPSender(httpMethod string, url string, headers http.Header, body string, timeout time.Duration, urlEncodeBodyReplacement bool) (*HTTPSender, error) {
 	if httpMethod == "" {
 		return nil, errors.New("http method has to have some value, but that is empty")
 	}
@@ -36,7 +36,7 @@ func NewHTTPSender(httpMethod string, url string, headers http.Header, body stri
 		Client: &http.Client{
 			Timeout: timeout,
 		},
-		URLEncodeBody: urlEncodeBody,
+		URLEncodeBodyReplacement: urlEncodeBodyReplacement,
 	}, nil
 }
 
@@ -55,10 +55,11 @@ func (s *HTTPSender) Send(line string) error {
 		}()
 	}
 
-	body := replacePlaceholder(s.Body, line)
-	if s.URLEncodeBody {
-		body = url.QueryEscape(body)
+	lineForBody := line
+	if s.URLEncodeBodyReplacement {
+		lineForBody = url.QueryEscape(line)
 	}
+	body := replacePlaceholder(s.Body, lineForBody)
 
 	req, err := http.NewRequest(s.HTTPMethod, webhookURL, strings.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
Now it escapes only the replacement of the body instead of the entire body.

past:

`{{ line }} = "$foo #bar"` and the body is `message={{ line }}`, then it
escapes the body as `message%3D%24foo+%23bar`

current:

`{{ line }} = "$foo #bar"` and the body is `message={{ line }}`, then it
escapes the body as `message=%24foo+%23bar`

ref #3 